### PR TITLE
chore: add project config files and update README thesis counts

### DIFF
--- a/.claude/commands/new-feature.md
+++ b/.claude/commands/new-feature.md
@@ -1,0 +1,50 @@
+# New Feature Workflow
+
+Set up a complete feature development workflow: GitHub issue + branch + initial structure.
+
+## Arguments
+$ARGUMENTS - Description of the feature to implement
+
+## Steps
+
+1. **Create GitHub Issue** — Using `gh issue create`:
+   - Title: concise description of the feature
+   - Labels: `feature` (or `fix`, `security`, `chore` as appropriate)
+   - Body format:
+     ```
+     ## Description
+     What needs to happen
+
+     ## Motivation
+     Why this change is needed
+
+     ## Acceptance Criteria
+     - [ ] How to verify it's done
+
+     ## Technical Notes
+     Implementation hints if relevant
+     ```
+
+2. **Create branch** — From latest `main`:
+   - `git checkout main && git pull origin main`
+   - Branch naming: `feature/<short-description>` (or `fix/`, `chore/`, `security/`)
+   - `git checkout -b <branch-name>`
+
+3. **Report** — Output:
+   - Issue URL and number
+   - Branch name
+   - Remind the user to use `/pr` when the feature is ready
+
+## Implementation Checklist (follow for every feature)
+
+After setup, when implementing the feature, always follow this order:
+
+1. **Implement** — write the feature code
+2. **Test manually** — open index.html in a browser or use a local server
+3. **Commit** — include the issue number in commit body (`Closes #N`)
+
+## Important
+- Always start from an up-to-date `main`
+- The branch name should be kebab-case and descriptive but short
+- If the description ($ARGUMENTS) is unclear, ask the user for clarification before creating anything
+- Reference the issue number in all subsequent commits on this branch

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,42 @@
+# Create Pull Request
+
+Create a complete Pull Request following the project's git workflow.
+
+## Steps
+
+1. **Verify branch** — Ensure we're NOT on `main`:
+   - If on `main`, ask the user which branch to create
+   - The branch must follow naming: `feature/<desc>`, `fix/<desc>`, `chore/<desc>`, `security/<desc>`
+
+2. **Stage and commit** — Stage all relevant changes:
+   - Review `git status` and `git diff` to understand what changed
+   - Stage files explicitly (never `git add -A` for safety)
+   - Do NOT stage `.env`, credentials, or `.claude/settings.local.json`
+   - Write a conventional commit message: `<type>: <description>`
+   - Include `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>`
+
+3. **Push** — Push the branch to origin:
+   - `git push -u origin <branch-name>`
+
+4. **Create PR** — Use `gh pr create`:
+   - Title: concise, under 70 characters
+   - Body format:
+     ```
+     ## Summary
+     - bullet points of changes
+
+     ## Related Issue
+     Closes #N
+
+     ## Test Plan
+     - [ ] checklist of verification steps
+
+     Generated with Claude Code
+     ```
+   - Add appropriate labels: `feature`, `fix`, `chore`, `security`, `docs`
+
+5. **Report** — Output the PR URL to the user
+
+## Important
+- NEVER force-push or push to `main` directly
+- If there's no linked issue, ask the user if they want to create one first

--- a/.claude/commands/security-check.md
+++ b/.claude/commands/security-check.md
@@ -1,0 +1,42 @@
+# Security Audit
+
+Perform a security audit of the codebase against the project's security rules.
+
+## Checks to Perform
+
+### 1. Content Security
+- [ ] No `eval()`, `new Function()`, or `document.write()`
+- [ ] No `innerHTML` with dynamic user-generated content (use `textContent`)
+- [ ] No inline event handlers in HTML (`onclick`, `onload`, etc.)
+- [ ] No dynamic script loading from untrusted sources
+
+### 2. External Resources
+- [ ] All CDN-hosted resources use `integrity` attribute (SRI)
+- [ ] External resources come from well-known, trusted CDNs only
+- [ ] No loading of resources from unknown third-party domains
+
+### 3. Data Integrity
+- [ ] All candidate positions are sourced from committed data files
+- [ ] No URL parameters or user input can alter displayed political data
+- [ ] Score calculation logic is transparent and correct
+
+### 4. Privacy
+- [ ] No analytics, tracking scripts, or cookies
+- [ ] No data sent to any external server
+- [ ] No localStorage usage beyond user preferences
+
+### 5. General Web Security
+- [ ] No sensitive information in HTML comments or JS comments
+- [ ] No hardcoded API keys or tokens
+- [ ] `.gitignore` excludes sensitive files
+
+## Output Format
+Report findings as a table:
+
+| Severity | File | Issue | Status |
+|----------|------|-------|--------|
+| Critical | path/to/file | Description | OPEN / FIXED |
+| Warning | path/to/file | Description | OPEN / FIXED |
+| Info | path/to/file | Description | OPEN / FIXED |
+
+Then suggest GitHub issues to create for any OPEN findings with `security` label.

--- a/.claude/hooks/enforce-branch.sh
+++ b/.claude/hooks/enforce-branch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block file edits on main branch
+# Reads tool input from stdin as JSON
+
+set -euo pipefail
+
+input=$(cat)
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+if [ "$branch" = "main" ]; then
+  # Extract file_path from tool input (Edit/Write/NotebookEdit)
+  file_path=$(echo "$input" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('file_path', d.get('notebook_path', '')))
+" 2>/dev/null || echo "")
+
+  # Allow edits to .claude/ files and memory even on main
+  if [[ "$file_path" == *"/.claude/"* ]] || [[ "$file_path" == *".claude/"* ]]; then
+    exit 0
+  fi
+
+  echo "BLOCKED: you are on the 'main' branch."
+  echo ""
+  echo "Every code change must go through:"
+  echo "  1. gh issue create ...          (create a GitHub issue)"
+  echo "  2. git checkout -b <type>/<name> (create a branch)"
+  echo "  3. Implement + commit"
+  echo "  4. gh pr create ...             (open a PR)"
+  echo ""
+  echo "Branch types: feature/ fix/ security/ chore/ docs/"
+  exit 1
+fi

--- a/.claude/hooks/remind-git-workflow.sh
+++ b/.claude/hooks/remind-git-workflow.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PostToolUse hook: remind Claude to follow the full git workflow after any file edit.
+# Fires after Edit, Write, NotebookEdit.
+
+set -euo pipefail
+
+cat <<'REMINDER'
+---------------------------------------------------
+GIT WORKFLOW REMINDER (automated hook)
+---------------------------------------------------
+A file was just modified. If this task is complete,
+you MUST immediately (without being asked) execute:
+
+  1. gh issue create ...              (create a GitHub issue)
+  2. git checkout -b <type>/<name>    (create a branch)
+  3. git add <files> && git commit    (commit the changes)
+  4. git push -u origin <branch>      (push)
+  5. gh pr create ...                 (open a PR)
+  6. gh pr merge <n> --squash --delete-branch  (merge + cleanup)
+  7. git checkout main && git pull    (sync local main)
+
+This applies to ALL files, including .claude/ files.
+---------------------------------------------------
+REMINDER

--- a/.claude/rules/00-code-style.md
+++ b/.claude/rules/00-code-style.md
@@ -1,0 +1,36 @@
+# Code Style
+
+## HTML
+
+- **Semantic markup**: Use appropriate HTML5 elements (`<header>`, `<main>`, `<section>`, `<article>`, `<nav>`, `<footer>`).
+- **Accessibility**: All interactive elements must be keyboard-accessible. Images must have `alt` attributes. Form inputs must have associated `<label>` elements.
+- **Language**: Set `lang="fr"` on `<html>` — this is a French-language tool for Strasbourg elections.
+- **Encoding**: Always use `<meta charset="UTF-8">`.
+- **No inline event handlers**: Use `addEventListener` in JavaScript instead of `onclick`, `onsubmit`, etc.
+
+## CSS
+
+- **No CSS framework**: Use native CSS with CSS variables defined in `:root`.
+- **Naming**: Use descriptive short class names. Follow existing patterns in the codebase.
+- **Units**: Use `px` for fixed sizes, `%` or `vw`/`vh` for relative. Font sizes in `rem` or `px`.
+- **Transitions**: Keep transitions short (100-200ms) for responsiveness.
+- **No inline styles**: Exceptions only for truly dynamic values (widths, positions from data).
+- **Responsive**: Mobile-first approach. Use media queries for larger screens.
+
+## JavaScript
+
+- **No framework dependency**: This is a vanilla JavaScript project. Do not introduce React, Vue, or other frameworks.
+- **Strict mode**: Use `'use strict';` at the top of scripts or use ES modules (which are strict by default).
+- **Naming**: camelCase for functions/variables, UPPER_SNAKE_CASE for constants, PascalCase for constructor functions.
+- **No console.log in production**: Remove debug logs before commit.
+- **String literals**: Use template literals for interpolation, single quotes for simple strings.
+- **Error handling**: Always catch and handle promise rejections. Show user-facing errors via UI, not console.
+- **No `var`**: Use `const` by default, `let` when reassignment is needed.
+- **Data separation**: Keep data (candidates, theses, positions) separate from application logic.
+
+## General
+
+- **File size**: Keep files under 500 lines. Split when approaching this limit.
+- **Comments**: Only where the "why" isn't obvious. No commented-out code in commits.
+- **TODOs**: Use `// TODO:` with a description. Every TODO should reference a GitHub issue number.
+- **Dead code**: Remove unused code immediately. Don't keep "just in case".

--- a/.claude/rules/01-security.md
+++ b/.claude/rules/01-security.md
@@ -1,0 +1,33 @@
+# Security Rules
+
+## Static Site Security
+
+This is a static site hosted on GitHub Pages. There is no backend server, database, or authentication system. Security concerns are limited to frontend code.
+
+## Mandatory Rules
+
+### Content Integrity
+- NEVER load scripts from untrusted third-party domains.
+- External resources (fonts, icons) should come from well-known CDNs only.
+- No `eval()`, `new Function()`, or `innerHTML` with dynamic user-generated content.
+- No `document.write()`.
+
+### Data Integrity
+- Candidate positions, theses, and sources must be verifiable and sourced.
+- Never programmatically alter displayed data based on URL parameters or user input in a way that could mislead.
+- All data displayed to users must come from the committed data files.
+
+### Privacy
+- No analytics, tracking, or cookies unless explicitly requested by the user.
+- No data is sent to any server — all computation happens client-side.
+- No localStorage usage for anything beyond user preferences (theme, language).
+
+### XSS Prevention
+- Sanitize any user input before rendering it in the DOM.
+- Use `textContent` instead of `innerHTML` when inserting dynamic text.
+- If `innerHTML` is necessary, escape all special characters first.
+
+### Dependencies
+- Minimize external dependencies. This is a static site — every dependency is an attack surface.
+- If a CDN-hosted resource is used, include an `integrity` attribute (SRI hash).
+- Prefer self-hosted assets when possible.

--- a/.claude/rules/02-git-workflow.md
+++ b/.claude/rules/02-git-workflow.md
@@ -1,0 +1,100 @@
+# Git Workflow
+
+## Branch Strategy
+
+- **Main branch**: `main` — always deployable, protected.
+- **Feature branches**: `feature/<short-description>` (e.g., `feature/responsive-results`)
+- **Bug fix branches**: `fix/<short-description>` (e.g., `fix/score-calculation`)
+- **Chore branches**: `chore/<short-description>` (e.g., `chore/update-sources`)
+
+## Language
+
+**Everything that enters git MUST be written in English**, regardless of the language used in the conversation between the user and Claude:
+
+- Commit messages (subject line and body)
+- Branch names
+- GitHub issue titles and bodies
+- Pull request titles and bodies
+- Code comments and documentation strings
+- Variable names, function names, and identifiers
+
+The only exceptions are:
+- User-facing UI strings in HTML/JS (which are in French)
+- Content data (candidate names, thesis texts, source excerpts)
+- README.md and CONTRIBUTING.md (which are in French by design)
+
+## Commit Conventions
+
+Use Conventional Commits format:
+
+<type>: <short description>
+
+[optional body]
+
+[optional footer]
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+
+### Types
+- `feat`: New feature or capability
+- `fix`: Bug fix
+- `refactor`: Code restructuring without behavior change
+- `chore`: Tooling, deps, CI changes
+- `docs`: Documentation only
+- `style`: Formatting fixes (no logic change)
+- `perf`: Performance improvement
+- `security`: Security fix or hardening
+
+### Rules
+- Keep the subject line under 72 characters.
+- Use imperative mood ("add feature" not "added feature").
+- Reference GitHub issue numbers in the body when applicable (e.g., `Closes #12`).
+
+## GitHub Workflow
+
+### For every feature or bug fix:
+1. **Create a GitHub Issue** first — describe what needs to be done and why.
+2. **Create a branch** from `main` following the naming convention.
+3. **Implement** the change with clean, focused commits.
+4. **Create a Pull Request** targeting `main`:
+   - Title: concise, matches the issue
+   - Body: summary of changes, test plan, link to issue (`Closes #N`)
+5. **Squash merge** the PR into `main`.
+6. **Delete the feature branch** after merge.
+
+## Claude Code Automation
+
+### Auto commit/push/PR
+After completing any task that modifies source files, Claude MUST automatically (without waiting to be asked):
+1. Create a GitHub issue
+2. Create a branch and commit
+3. Push and open a PR
+
+Do not wait for the user to say "commit" or "push". Execute the full git workflow as part of every task completion.
+
+### No heredocs in Bash commands
+
+**NEVER use heredoc syntax in Bash commands.** The `*` glob in `permissions.allow` does
+not match newlines, so any multiline Bash command triggers a confirmation prompt even
+when the command starts with an allowed prefix like `git` or `gh`.
+
+Instead, write multiline content using the **Write tool** to a file **inside the workspace**
+(`.claude/tmp/`), then reference it in a single-line command:
+
+| Wrong | Correct |
+|---|---|
+| `git commit -m "$(cat <<'EOF'\n...\nEOF\n)"` | Write -> `.claude/tmp/commit_msg.txt` -> `git commit -F .claude/tmp/commit_msg.txt` |
+| `gh pr create --body "$(cat <<'EOF'\n...\nEOF\n)"` | Write -> `.claude/tmp/body.txt` -> `gh pr create --body "$(cat .claude/tmp/body.txt)"` |
+| `gh issue create --body "$(cat <<'EOF'\n...\nEOF\n)"` | Write -> `.claude/tmp/body.txt` -> `gh issue create --body "$(cat .claude/tmp/body.txt)"` |
+
+**Key**: `/tmp/` is outside the workspace -> still asks for permission in `acceptEdits` mode.
+`.claude/tmp/` is inside the workspace -> auto-approved. It is listed in `.gitignore`.
+
+The resulting single-line commands match `Bash(git *)` / `Bash(gh *)` and run without prompts.
+
+## Parallel Work with Worktrees
+
+For tasks that are independent of each other, use git worktrees to isolate each session:
+
+```bash
+claude --worktree feature/<name>   # launch from terminal for a new isolated session
+```

--- a/.claude/rules/03-privacy.md
+++ b/.claude/rules/03-privacy.md
@@ -1,0 +1,39 @@
+# Privacy — No Machine-Specific Paths
+
+## Rule: Never commit personal paths or usernames to git
+
+This project's `.claude/settings.json` is committed to a **public** GitHub repository.
+It MUST NOT contain any machine-specific or personal information.
+
+### Forbidden in any committed file
+
+- Absolute paths containing a username: `/Users/<name>/`, `/home/<name>/`
+- Personal tool paths: `/Users/<name>/.local/bin`
+- Any path that would expose the developer's username or home directory layout
+
+### settings.json — PATH rule
+
+The `env.PATH` in `.claude/settings.json` MUST only contain generic, machine-agnostic paths:
+
+```json
+"PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+```
+
+If you need to add a non-standard tool path during a session, do NOT edit settings.json.
+Instead, add the path to your **shell profile** (`~/.zshrc`, `~/.bashrc`) so it is available system-wide without polluting the committed config.
+
+### Hook commands — use relative paths
+
+Hook commands in `settings.json` MUST use paths relative to the project root:
+
+```json
+"command": "bash .claude/hooks/enforce-branch.sh"   (correct)
+"command": "bash /Users/<name>/project/.claude/hooks/enforce-branch.sh"   (wrong)
+```
+
+### If you accidentally commit personal paths
+
+1. Fix the file immediately.
+2. Run `git filter-repo --replace-text .claude/tmp/replacements.txt --force` to rewrite history.
+3. Force-push to remove the exposure from GitHub.
+4. Update this rule file if the pattern is new.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,68 @@
+{
+  "env": {
+    "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+  },
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch",
+      "NotebookEdit",
+      "TodoWrite",
+      "Task",
+      "Bash(git *)",
+      "Bash(PATH=* git *)",
+      "Bash(gh *)",
+      "Bash(source *)",
+      "Bash(export *)",
+      "Bash(find *)",
+      "Bash(ls *)",
+      "Bash(ls)",
+      "Bash(open *)",
+      "Bash(cat *)",
+      "Bash(mkdir *)",
+      "Bash(rm *)",
+      "Bash(cp *)",
+      "Bash(mv *)",
+      "Bash(which *)",
+      "Bash(echo *)",
+      "Bash(pwd)",
+      "Bash(wc *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(sort *)",
+      "Bash(diff *)",
+      "Bash(python3 *)",
+      "Bash(node *)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/enforce-branch.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/remind-git-workflow.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+*.swp
+*.swo
+*~
+.vscode/
+.idea/
+
+# Claude Code temporary files
+.claude/tmp/
+.claude/worktrees/
+
+# Local settings (not committed)
+.claude/settings.local.json
+
+# Environment
+.env
+.env.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# Wahl-O-Mat · Strasbourg 2026
+
+A citizen decision-aid tool for the 2026 Strasbourg municipal elections, inspired by the German Wahl-O-Mat.
+
+## Mandatory Git Workflow (enforced by hook)
+
+**NEVER edit source files directly on `main`.** Every code change MUST follow this process:
+
+1. `gh issue create ...` — create a GitHub issue first
+2. `git checkout -b <type>/<name>` — create a branch (`feature/`, `fix/`, `security/`, `chore/`)
+3. Implement + commit (following Conventional Commits)
+4. `gh pr create ...` — open a PR targeting `main`
+5. Squash merge + delete branch
+
+A `PreToolUse` Claude Code hook enforces this: any file edit attempt on `main` is blocked.
+Exception: `.claude/` files (memory, settings, hooks) may be edited on any branch.
+
+## Tech Stack
+
+- **Frontend**: Vanilla HTML5, CSS3 (native variables), JavaScript (ES6+)
+- **Hosting**: GitHub Pages (static site)
+- **No build step**: The site runs directly from source files
+- **No framework**: No React, Vue, Angular — intentionally kept simple and dependency-free
+
+## Commands
+
+```bash
+# Development
+open index.html              # Open in browser (macOS)
+python3 -m http.server 8000  # Local dev server (for module imports)
+
+# Git workflow
+git status                   # Check working tree
+git diff                     # Review changes
+gh issue create ...          # Create issue
+gh pr create ...             # Create pull request
+```
+
+## Architecture
+
+```
+wahl-o-mat/
+├── index.html               ← Main application (single-page)
+├── README.md                ← Project documentation (French)
+├── CONTRIBUTING.md          ← Contribution guide (French)
+├── LICENSE                  ← MIT license
+├── CLAUDE.md                ← This file (Claude Code instructions)
+├── .claude/
+│   ├── settings.json        ← Claude Code permissions & hooks
+│   ├── rules/
+│   │   ├── 00-code-style.md ← HTML/CSS/JS coding standards
+│   │   ├── 01-security.md   ← Web security rules
+│   │   ├── 02-git-workflow.md ← Git branch & commit conventions
+│   │   └── 03-privacy.md   ← No personal paths in committed files
+│   ├── hooks/
+│   │   ├── enforce-branch.sh ← Block edits on main branch
+│   │   └── remind-git-workflow.sh ← Remind to commit/push/PR
+│   └── commands/
+│       ├── new-feature.md   ← /new-feature: issue + branch setup
+│       ├── pr.md            ← /pr: create pull request
+│       └── security-check.md ← /security-check: audit codebase
+└── .gitignore
+```
+
+## Important Notes
+
+- **Language duality**: Code, git messages, and technical docs are in English. User-facing content (UI, README, CONTRIBUTING) is in French.
+- **Data integrity is critical**: This tool displays political positions attributed to real candidates. Every position must be sourced from verifiable press articles. Never fabricate or guess positions.
+- **Neutrality**: The tool must remain strictly non-partisan. No thesis should be formulated to advantage or disadvantage any candidate.
+- **Accessibility**: The site must be usable on mobile and by screen readers. Semantic HTML and keyboard navigation are required.
+- **No tracking**: No analytics, no cookies, no external data collection. All computation is client-side.
+
+## Rules
+
+Detailed rules are auto-loaded from `.claude/rules/`:
+
+@.claude/rules/00-code-style.md
+@.claude/rules/01-security.md
+@.claude/rules/02-git-workflow.md
+@.claude/rules/03-privacy.md

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Outil citoyen d'aide à la décision pour les élections municipales de Strasbou
 
 ## À propos
 
-Ce Wahl-O-Mat compare vos positions à celles des 6 principaux candidats à la mairie de Strasbourg sur 23 thèses issues des grands enjeux de la campagne : mobilité, logement, sécurité, finances, écologie, démocratie, tourisme et social.
+Ce Wahl-O-Mat compare vos positions à celles des 6 principaux candidats à la mairie de Strasbourg sur 33 thèses issues des grands enjeux de la campagne : mobilité, logement, sécurité, finances, écologie, démocratie, tourisme, social, urbanisme et économie.
 
 **Ce que cet outil est :**
 - Un aide-mémoire pédagogique sur les programmes
@@ -60,13 +60,13 @@ L'utilisation de l'IA ne garantit pas l'absence d'erreurs. Elle peut introduire 
 
 ### Choix des candidats
 
-Strasbourg compte 10 listes officiellement déposées. Seuls 6 candidats figurent dans cet outil, pour une raison unique : ce sont les seuls dont il a été possible de documenter des positions **suffisamment précises et vérifiables** sur chacune des 23 thèses. Ce critère est purement méthodologique et ne reflète aucun jugement sur la valeur des candidatures absentes.
+Strasbourg compte 10 listes officiellement déposées. Seuls 6 candidats figurent dans cet outil, pour une raison unique : ce sont les seuls dont il a été possible de documenter des positions **suffisamment précises et vérifiables** sur chacune des 33 thèses. Ce critère est purement méthodologique et ne reflète aucun jugement sur la valeur des candidatures absentes.
 
 Les candidats absents et les raisons de leur absence sont expliqués dans l'outil lui-même.
 
 ### Choix des thèses
 
-Les 23 thèses ont été sélectionnées à partir des sujets les plus présents dans la couverture de campagne par la presse locale (Rue89 Strasbourg, Pokaa, StrasInfo, Vert.eco, France Bleu, France 3, CNews). Elles couvrent 8 thèmes : mobilité, logement, sécurité, finances, écologie, démocratie, tourisme, social.
+Les 33 thèses ont été sélectionnées à partir des sujets les plus présents dans la couverture de campagne par la presse locale (Rue89 Strasbourg, Pokaa, StrasInfo, Vert.eco, France Bleu, France 3, CNews). Elles couvrent 10 thèmes : mobilité, logement, sécurité, finances, écologie, démocratie, tourisme, social, urbanisme et économie.
 
 Tout choix de thèses implique un cadrage. Certains sujets sont absents faute de sources permettant d'attribuer des positions claires à tous les candidats. Ce biais de documentation est inhérent à l'exercice.
 


### PR DESCRIPTION
## Summary

- Add Claude Code project configuration (`.claude/` directory with settings, hooks, rules, and slash commands)
- Add `CLAUDE.md` with project instructions, architecture, and workflow documentation
- Add `.gitignore` for OS files, editor files, and Claude Code temp files
- Update `README.md`: thesis count 23 → 33, theme count 8 → 10 (added urbanisme and économie)

Closes #4

## Test plan

- [ ] Verify no personal paths or usernames appear in any committed file
- [ ] Verify `.gitignore` correctly excludes `.claude/tmp/` and `.claude/worktrees/`
- [ ] Verify README numbers match the actual thesis/theme counts in `index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)