### PR TITLE
fix: pre-select top 3 candidates by score in comparison table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1374,7 +1374,7 @@ CANDIDATES.forEach(c => { c.positions = POSITIONS[c.id] || {}; });
 // =============================================
 let currentIndex = 0;
 const userAnswers = {}; // T1 => { vote: 'agree'|'neutral'|'disagree'|'skip', double: bool }
-let selectedCandidates = new Set(['barseghian', 'trautmann', 'vetter']);
+let selectedCandidates = new Set();
 
 // =============================================
 // QUIZ LOGIC
@@ -1546,6 +1546,7 @@ function showResults() {
     }, 100 + i * 150);
   });
 
+  selectedCandidates = new Set(scores.slice(0, 3).map(c => c.id));
   buildComparisonTable();
   buildCompCheckboxes(scores);
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded pre-selection of 3 candidates (Barseghian, Trautmann, Vetter) in the comparison table with dynamic selection of the user's top 3 scoring candidates
- `selectedCandidates` is now initialized empty and populated from sorted scores in `showResults()`

## Test plan
- [x] All 76 existing tests pass
- [ ] Complete the quiz and verify the comparison table pre-selects the 3 candidates with the highest match scores
- [ ] Toggle candidates on/off and verify the table updates correctly

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)