### PR TITLE
feat: add user answers column to comparison table

### DIFF
--- a/index.html
+++ b/index.html
@@ -622,6 +622,7 @@
     white-space: nowrap;
   }
   .comp-table th.these-col { width: 280px; }
+  .comp-table th.vous-col { background: var(--ink); }
   .comp-table td {
     padding: 10px 14px;
     border-bottom: 1px solid var(--gray-light);
@@ -1645,6 +1646,7 @@ function buildComparisonTable() {
   const cands = candIds.map(id => CANDIDATES.find(c => c.id === id)).filter(Boolean);
 
   let html = '<thead><tr><th class="these-col">Thèse</th>';
+  html += '<th class="vous-col">Vous</th>';
   cands.forEach(c => { html += `<th style="color:white;background:${c.color}">${c.name.split(' ').pop()}</th>`; });
   html += '</tr></thead><tbody>';
 
@@ -1652,9 +1654,14 @@ function buildComparisonTable() {
   THESES.forEach(t => {
     if (t.category !== currentTheme) {
       currentTheme = t.category;
-      html += `<tr class="theme-row"><td colspan="${cands.length + 1}">${t.category}</td></tr>`;
+      html += `<tr class="theme-row"><td colspan="${cands.length + 2}">${t.category}</td></tr>`;
     }
     html += `<tr><td style="font-size:12px">${t.text}</td>`;
+    const uv = userAnswers[t.id]?.vote;
+    if (uv === 'agree') html += '<td class="cell-agree">✓</td>';
+    else if (uv === 'neutral') html += '<td class="cell-neutral">—</td>';
+    else if (uv === 'disagree') html += '<td class="cell-disagree">✗</td>';
+    else html += '<td class="cell-unknown">–</td>';
     cands.forEach(c => {
       const pos = POSITIONS[c.id]?.[t.id]?.stance;
       if (pos === 'agree') html += '<td class="cell-agree">✓</td>';

--- a/tests/comparison.test.js
+++ b/tests/comparison.test.js
@@ -20,6 +20,11 @@ describe('buildComparisonTable', () => {
   // -----------------------------------------------------------
   // Column headers
   // -----------------------------------------------------------
+  test('includes "Vous" column header', () => {
+    const html = getTableHTML();
+    expect(html).toContain('Vous');
+  });
+
   test('includes column header for each selected candidate', () => {
     const html = getTableHTML();
     // Default selectedCandidates: barseghian, trautmann, vetter
@@ -130,8 +135,8 @@ describe('buildComparisonTable', () => {
     // T1 is the first non-theme row
     const t1Row = rows[0];
     const cells = t1Row.querySelectorAll('td');
-    // Second cell (after thesis text) should be barseghian's stance
-    const stanceCell = cells[1];
+    // Third cell (after thesis text and Vous column) should be barseghian's stance
+    const stanceCell = cells[2];
     expect(stanceCell.className).toBe('cell-agree');
     expect(stanceCell.textContent).toBe('✓');
   });
@@ -156,8 +161,68 @@ describe('buildComparisonTable', () => {
 
     expect(t11Row).toBeTruthy();
     const cells = t11Row.querySelectorAll('td');
-    const stanceCell = cells[1];
+    const stanceCell = cells[2];
     expect(stanceCell.className).toBe('cell-disagree');
     expect(stanceCell.textContent).toBe('✗');
+  });
+
+  // -----------------------------------------------------------
+  // User answers column
+  // -----------------------------------------------------------
+  test('shows user agree answer as checkmark', () => {
+    app.userAnswers.T1 = { vote: 'agree', double: false };
+
+    app.buildComparisonTable();
+    const table = document.getElementById('comp-table');
+    const rows = table.querySelectorAll('tbody tr:not(.theme-row)');
+    const t1Row = rows[0];
+    const vousCell = t1Row.querySelectorAll('td')[1];
+    expect(vousCell.className).toBe('cell-agree');
+    expect(vousCell.textContent).toBe('✓');
+  });
+
+  test('shows user disagree answer as cross', () => {
+    app.userAnswers.T1 = { vote: 'disagree', double: false };
+
+    app.buildComparisonTable();
+    const table = document.getElementById('comp-table');
+    const rows = table.querySelectorAll('tbody tr:not(.theme-row)');
+    const t1Row = rows[0];
+    const vousCell = t1Row.querySelectorAll('td')[1];
+    expect(vousCell.className).toBe('cell-disagree');
+    expect(vousCell.textContent).toBe('✗');
+  });
+
+  test('shows user neutral answer as dash', () => {
+    app.userAnswers.T1 = { vote: 'neutral', double: false };
+
+    app.buildComparisonTable();
+    const table = document.getElementById('comp-table');
+    const rows = table.querySelectorAll('tbody tr:not(.theme-row)');
+    const t1Row = rows[0];
+    const vousCell = t1Row.querySelectorAll('td')[1];
+    expect(vousCell.className).toBe('cell-neutral');
+    expect(vousCell.textContent).toBe('—');
+  });
+
+  test('shows unknown indicator for skipped questions', () => {
+    app.userAnswers.T1 = { vote: 'skip', double: false };
+
+    app.buildComparisonTable();
+    const table = document.getElementById('comp-table');
+    const rows = table.querySelectorAll('tbody tr:not(.theme-row)');
+    const t1Row = rows[0];
+    const vousCell = t1Row.querySelectorAll('td')[1];
+    expect(vousCell.className).toBe('cell-unknown');
+  });
+
+  test('shows unknown indicator for unanswered questions', () => {
+    // T1 not in userAnswers at all
+    app.buildComparisonTable();
+    const table = document.getElementById('comp-table');
+    const rows = table.querySelectorAll('tbody tr:not(.theme-row)');
+    const t1Row = rows[0];
+    const vousCell = t1Row.querySelectorAll('td')[1];
+    expect(vousCell.className).toBe('cell-unknown');
   });
 });


### PR DESCRIPTION
## Summary

- Add a **"Vous"** column to the comparison table, displayed between the thesis text and the candidate columns
- Uses the same symbol system as candidates: ✓ (agree), — (neutral), ✗ (disagree), – (skipped/unanswered)
- Update theme separator `colspan` to account for the new column

## Test plan

- [x] All 81 existing tests pass (updated cell index references)
- [x] 5 new tests: Vous header, agree/disagree/neutral symbols, skipped and unanswered indicators
- [ ] Manual: complete the quiz and verify the "Vous" column appears in the comparison table

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)