### PR TITLE
feat: auto-advance to next question on vote click

### DIFF
--- a/index.html
+++ b/index.html
@@ -1394,6 +1394,7 @@ CANDIDATES.forEach(c => { c.positions = POSITIONS[c.id] || {}; });
 let currentIndex = 0;
 const userAnswers = {}; // T1 => { vote: 'agree'|'neutral'|'disagree'|'skip', double: bool }
 let selectedCandidates = new Set();
+let autoAdvanceTimer = null;
 
 // =============================================
 // QUIZ LOGIC
@@ -1441,6 +1442,8 @@ function renderQuestion() {
 }
 
 function castVote(type) {
+  if (autoAdvanceTimer) { clearTimeout(autoAdvanceTimer); autoAdvanceTimer = null; }
+
   const q = THESES[currentIndex];
   const existing = userAnswers[q.id] || {};
   const isDeselect = existing.vote === type;
@@ -1448,13 +1451,16 @@ function castVote(type) {
   document.querySelectorAll('.vote-btn').forEach(b => b.classList.remove('selected'));
   if (!isDeselect) document.querySelector(`.vote-btn.${type}`)?.classList.add('selected');
   updateNextLabel();
+
+  if (!isDeselect && !reviewMode) {
+    autoAdvanceTimer = setTimeout(function() { autoAdvanceTimer = null; nextQuestion(); }, 250);
+  }
 }
 
 function updateNextLabel() {
-  const q = THESES[currentIndex];
+  if (reviewMode) return;
   const isLast = currentIndex === THESES.length - 1;
-  const hasVote = userAnswers[q.id] && userAnswers[q.id].vote !== 'skip';
-  document.getElementById('btn-next').textContent = isLast ? 'Voir les résultats →' : (hasVote ? 'Suivant →' : 'Passer');
+  document.getElementById('btn-next').textContent = isLast ? 'Voir les résultats →' : 'Passer';
 }
 
 function toggleDoubleWeight() {
@@ -1465,6 +1471,8 @@ function toggleDoubleWeight() {
 }
 
 function nextQuestion() {
+  if (autoAdvanceTimer) { clearTimeout(autoAdvanceTimer); autoAdvanceTimer = null; }
+
   const q = THESES[currentIndex];
   if (!userAnswers[q.id]) userAnswers[q.id] = { vote: 'skip', double: false };
 
@@ -1489,6 +1497,7 @@ function nextQuestion() {
 }
 
 function prevQuestion() {
+  if (autoAdvanceTimer) { clearTimeout(autoAdvanceTimer); autoAdvanceTimer = null; }
   if (currentIndex > 0) {
     currentIndex--;
     renderQuestion();
@@ -1685,6 +1694,7 @@ function showTab(tab) {
 }
 
 function restartQuiz() {
+  if (autoAdvanceTimer) { clearTimeout(autoAdvanceTimer); autoAdvanceTimer = null; }
   Object.keys(userAnswers).forEach(k => delete userAnswers[k]);
   currentIndex = 0;
   reviewMode = false;

--- a/tests/auto-advance.test.js
+++ b/tests/auto-advance.test.js
@@ -1,0 +1,107 @@
+import { describe, test, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest';
+import { loadApp, resetState } from './helpers/load-app.js';
+
+describe('auto-advance on vote', () => {
+  let app;
+
+  beforeAll(() => { app = loadApp(); });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetState(app);
+    app.startQuiz();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('castVote schedules auto-advance after 250ms', () => {
+    expect(app.currentIndex).toBe(0);
+    app.castVote('agree');
+    expect(app.currentIndex).toBe(0);
+    vi.advanceTimersByTime(250);
+    expect(app.currentIndex).toBe(1);
+  });
+
+  test('deselecting a vote does not auto-advance', () => {
+    app.userAnswers[app.THESES[0].id] = { vote: 'agree', double: false };
+    app.renderQuestion();
+    app.castVote('agree');
+    vi.advanceTimersByTime(500);
+    expect(app.currentIndex).toBe(0);
+    expect(app.userAnswers[app.THESES[0].id].vote).toBe('skip');
+  });
+
+  test('rapid click on different vote resets timer', () => {
+    app.castVote('agree');
+    vi.advanceTimersByTime(100);
+    app.castVote('disagree');
+    vi.advanceTimersByTime(200);
+    expect(app.currentIndex).toBe(0);
+    vi.advanceTimersByTime(50);
+    expect(app.currentIndex).toBe(1);
+    expect(app.userAnswers[app.THESES[0].id].vote).toBe('disagree');
+  });
+
+  test('rapid double-click on same vote deselects and stays', () => {
+    app.castVote('agree');
+    vi.advanceTimersByTime(50);
+    app.castVote('agree');
+    vi.advanceTimersByTime(500);
+    expect(app.currentIndex).toBe(0);
+    expect(app.userAnswers[app.THESES[0].id].vote).toBe('skip');
+  });
+
+  test('no auto-advance in review mode', () => {
+    app.reviewMode = true;
+    app.castVote('agree');
+    vi.advanceTimersByTime(500);
+    expect(app.currentIndex).toBe(0);
+  });
+
+  test('last question auto-advances to results', () => {
+    app.currentIndex = app.THESES.length - 1;
+    app.renderQuestion();
+    app.castVote('agree');
+    vi.advanceTimersByTime(250);
+    expect(document.getElementById('screen-quiz').style.display).toBe('none');
+    expect(document.getElementById('screen-results').style.display).toBe('block');
+  });
+
+  test('prevQuestion cancels pending auto-advance', () => {
+    app.currentIndex = 1;
+    app.renderQuestion();
+    app.castVote('agree');
+    vi.advanceTimersByTime(100);
+    app.prevQuestion();
+    vi.advanceTimersByTime(300);
+    expect(app.currentIndex).toBe(0);
+  });
+});
+
+describe('button label', () => {
+  let app;
+
+  beforeAll(() => { app = loadApp(); });
+
+  beforeEach(() => {
+    resetState(app);
+    app.startQuiz();
+  });
+
+  test('btn-next always shows "Passer" (not "Suivant") after vote', () => {
+    app.castVote('agree');
+    expect(document.getElementById('btn-next').textContent).toBe('Passer');
+  });
+
+  test('btn-next shows "Passer" when no vote', () => {
+    expect(document.getElementById('btn-next').textContent).toBe('Passer');
+  });
+
+  test('btn-next shows "Voir les résultats →" on last question', () => {
+    app.currentIndex = app.THESES.length - 1;
+    app.renderQuestion();
+    expect(document.getElementById('btn-next').textContent).toBe('Voir les résultats →');
+  });
+});

--- a/tests/helpers/load-app.js
+++ b/tests/helpers/load-app.js
@@ -43,7 +43,9 @@ export function loadApp() {
       get currentIndex() { return currentIndex; },
       set currentIndex(v) { currentIndex = v; },
       get reviewMode() { return reviewMode; },
-      set reviewMode(v) { reviewMode = v; }
+      set reviewMode(v) { reviewMode = v; },
+      get autoAdvanceTimer() { return autoAdvanceTimer; },
+      set autoAdvanceTimer(v) { autoAdvanceTimer = v; }
     };
   })()`;
 
@@ -55,6 +57,7 @@ export function loadApp() {
  * Call in beforeEach to isolate tests.
  */
 export function resetState(app) {
+  if (app.autoAdvanceTimer) { clearTimeout(app.autoAdvanceTimer); app.autoAdvanceTimer = null; }
   Object.keys(app.userAnswers).forEach(k => delete app.userAnswers[k]);
   app.currentIndex = 0;
   app.reviewMode = false;


### PR DESCRIPTION
## Summary

- Clicking a vote button ("D'accord", "Indifférent", "Pas d'accord") now auto-advances to the next question after 250ms of visual feedback
- Re-clicking a selected vote when navigating back deselects it (toggle behavior), staying on the question
- Replaced the dynamic "Suivant"/"Passer" label with a static "Passer" button (always visible)
- Added rapid-click protection (timer cancellation prevents double-advance)
- Review mode is excluded from auto-advance (user must click "Valider…")

Closes #18

## Test plan

- [x] 10 new tests in `tests/auto-advance.test.js` (using `vi.useFakeTimers`)
- [x] All 96 tests pass (7 test files)
- [ ] Manual: click a vote → should highlight briefly then advance
- [ ] Manual: go back → click same vote → deselects, stays on question → click "Passer" → advances
- [ ] Manual: last question vote → auto-advances to results
- [ ] Manual: review mode (edit from results) → no auto-advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)