### PR TITLE
feat: show total thesis count in question number (e.g. Thèse 1/33)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1409,7 +1409,7 @@ function startQuiz() {
 function renderQuestion() {
   const q = THESES[currentIndex];
   document.getElementById('question-theme').textContent = q.category;
-  document.getElementById('question-number').textContent = q.label;
+  document.getElementById('question-number').textContent = `${q.label} / ${THESES.length}`;
   document.getElementById('question-text').textContent = q.text;
 
   // Documentation links


### PR DESCRIPTION
Show total thesis count in question number label

## Summary
- The question-number label now shows "Thèse 1 / 33" instead of just "Thèse 1"
- One-line change in `renderQuestion()`: template literal adds ` / ${THESES.length}`

## Test plan
- [x] All 96 existing tests pass
- [x] No new tests needed (pure display change, no logic change)

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)