### PR TITLE
feat: add GitHub repository link in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -844,7 +844,7 @@
 
 <footer class="site-footer">
   <p>Outil citoyen non-partisan · Données issues des programmes officiels et de la presse locale (Rue89 Strasbourg, Pokaa, StrasInfo, Vert.eco, France Bleu, CNews) · Mars 2026</p>
-  <p style="margin-top:6px">Pas de recommandation de vote · <a href="#" onclick="showSources()">Voir toutes les sources</a></p>
+  <p style="margin-top:6px">Pas de recommandation de vote · <a href="#" onclick="showSources()">Voir toutes les sources</a> · <a href="https://github.com/sgoger/wahl-o-mat-municipales-strasbourg-2026" target="_blank" rel="noopener noreferrer">Code source sur GitHub</a></p>
 </footer>
 
 <script>


### PR DESCRIPTION
## Summary

- Add "Code source sur GitHub" link in the page footer
- Opens in a new tab with `rel="noopener noreferrer"` for security
- Placed next to the existing "Voir toutes les sources" link

## Test plan

- [ ] Link appears in the footer
- [ ] Clicking opens the GitHub repository in a new tab

Closes #22