### PR TITLE
fix: undocumented neutral positions score 0 instead of 1 point

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Chaque position (`D'accord` / `Neutre` / `Pas d'accord`) est :
 
 Pour chaque thèse répondue :
 - Accord avec le candidat → **2 points**
-- Position de l'un des deux côtés `Neutre` → **1 point**
+- Position de l'un des deux côtés `Neutre` (position modérée documentée) → **1 point**
+- Position non documentée du candidat (aucune source) → **0 point**
 - Désaccord → **0 point**
 
 Les thèses marquées "×2" comptent double. Le score final est le ratio entre les points obtenus et le maximum possible, exprimé en pourcentage.

--- a/index.html
+++ b/index.html
@@ -1514,15 +1514,17 @@ function calcScore(candidateId) {
   THESES.forEach(t => {
     const ua = userAnswers[t.id];
     if (!ua || ua.vote === 'skip') return;
-    const cp = POSITIONS[candidateId]?.[t.id]?.stance;
-    if (!cp) return;
+    const cpEntry = POSITIONS[candidateId]?.[t.id];
+    if (!cpEntry?.stance) return;
+    const cp = cpEntry.stance;
 
     const weight = ua.double ? 2 : 1;
     maxScore += 2 * weight;
 
     if (ua.vote === cp) score += 2 * weight;
-    else if (ua.vote === 'neutral' || cp === 'neutral') score += 1 * weight;
-    // else: 0 points
+    else if (ua.vote === 'neutral') score += 1 * weight;
+    else if (cp === 'neutral' && !isUndocumented(cpEntry.excerpt)) score += 1 * weight;
+    // undocumented neutral + user non-neutral → 0 points
   });
 
   return maxScore > 0 ? Math.round((score / maxScore) * 100) : 0;

--- a/tests/scoring.test.js
+++ b/tests/scoring.test.js
@@ -94,6 +94,29 @@ describe('calcScore', () => {
   });
 
   // -----------------------------------------------------------
+  // Undocumented neutral
+  // -----------------------------------------------------------
+  describe('undocumented neutral', () => {
+    test('candidate undocumented neutral + user agree scores 0%', () => {
+      // jakubowicz T5 is neutral and undocumented ("Pas de position documentée sur les transports 24h/24")
+      app.userAnswers.T5 = { vote: 'agree', double: false };
+      expect(app.calcScore('jakubowicz')).toBe(0);
+    });
+
+    test('candidate undocumented neutral + user disagree scores 0%', () => {
+      // jakubowicz T5 is neutral and undocumented
+      app.userAnswers.T5 = { vote: 'disagree', double: false };
+      expect(app.calcScore('jakubowicz')).toBe(0);
+    });
+
+    test('candidate documented neutral + user agree still scores 50%', () => {
+      // barseghian T9 is neutral but documented ("Dispositif Mieux relouer mon logement vacant...")
+      app.userAnswers.T9 = { vote: 'agree', double: false };
+      expect(app.calcScore('barseghian')).toBe(50);
+    });
+  });
+
+  // -----------------------------------------------------------
   // Double weight
   // -----------------------------------------------------------
   describe('double weight', () => {


### PR DESCRIPTION
## Summary

- **Scoring fix**: undocumented neutral candidate stances now give **0 points** (was 1) when the user answers non-neutrally
- **3 new tests** covering the undocumented vs documented neutral distinction
- **README** updated with the new scoring rule

## Problem

`calcScore` was giving 1 partial-credit point to candidates with undocumented neutral positions regardless of the user's answer. Jakubowicz has 21 such positions — this inflated his score artificially.

## New scoring rule

| User answer | Candidate stance | Before | After |
|---|---|---|---|
| agree / disagree | Neutre (documenté) | 1 pt | 1 pt |
| agree / disagree | Non documenté | 1 pt | **0 pt** |
| neutral | any | 1 pt | 1 pt |
| neutral | neutral | 2 pts | 2 pts |

The `isUndocumented()` function (already present from PR #25) is now called inside `calcScore`.

## Test plan

- [x] 99/99 tests pass (`npm test`)
- [ ] Manual check: answer "D'accord" on all theses → Jakubowicz score should be lower than before (no free point on his 21 undocumented neutrals)
- [ ] Manual check: documented neutrals (barseghian T9) still give 50% when user answers "D'accord"

Closes #26