### PR TITLE
feat: add thematic distribution notice in intro card

### DIFF
--- a/index.html
+++ b/index.html
@@ -725,6 +725,18 @@
           <p>Consultez les résultats avec les positions sourcées de chaque candidat</p>
         </div>
       </div>
+      <details style="margin-top:12px;font-size:0.83rem;color:#555;border-top:1px solid #eee;padding-top:10px;">
+        <summary style="cursor:pointer;font-weight:600;color:#333;">Distribution thématique des 33 thèses</summary>
+        <div style="margin-top:8px;line-height:1.7;">
+          <p>Les thèses ont été sélectionnées à partir des sujets les plus couverts par la presse locale pendant la campagne. Cette couverture reflète le bilan de la maire sortante (Écologistes), ce qui crée un déséquilibre thématique :</p>
+          <ul style="padding-left:1.2rem;margin-top:6px;">
+            <li><strong>Thèmes à orientation plutôt progressiste</strong> (20 thèses) : mobilité, logement, écologie, démocratie, social</li>
+            <li><strong>Thèmes à orientation plutôt conservatrice</strong> (8 thèses) : sécurité (5), finances (2), simplification administrative (1)</li>
+            <li><strong>Thèmes mixtes</strong> (5 thèses) : tourisme, urbanisme, eau, stationnement</li>
+          </ul>
+          <p style="margin-top:8px;">Ce déséquilibre n'est pas un choix partisan — il traduit la réalité de la campagne médiatique. Utilisez la fonction <strong>×2</strong> pour donner plus de poids aux thèses qui comptent le plus pour vous.</p>
+        </div>
+      </details>
       <button class="btn-start" onclick="startQuiz()">Commencer le questionnaire →</button>
     </div>
 


### PR DESCRIPTION
## Summary

- Adds a collapsible `<details>` notice in the intro card before the start button
- Discloses the thematic distribution: **20 progressive / 8 conservative / 5 mixed** theses
- Explains the imbalance reflects press coverage, not partisan selection
- Suggests using ×2 weighting to give more weight to personally important theses

## Details

The notice is collapsed by default to keep the UI clean. Users who want to understand the tool's editorial limits can expand it. The text is factual and non-apologetic: it describes reality without suggesting the tool is biased.

No JavaScript logic was changed. No new tests needed.

## Test plan

- [x] 96/96 tests pass (`npm test`)
- [ ] Manual check: `<details>` block is visible in intro screen, collapsed by default
- [ ] Manual check: expanding it shows the 3-item breakdown and explanation text

Closes #28