### PR TITLE
feat: add political context paragraph for absent candidates

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,6 +766,12 @@
       <p style="margin-top:12px;font-size:0.82rem;color:#888;border-top:1px solid #eee;padding-top:10px;">
         Ces absences ne reflètent aucun jugement sur la valeur de ces candidatures. Elles résultent uniquement du <strong>critère de vérifiabilité</strong> appliqué uniformément : seules les positions documentées par des sources de presse indépendantes (Rue89 Strasbourg, Pokaa, StrasInfo, France Bleu, Vert.eco, CNews) ont été retenues.
       </p>
+      <p style="margin-top:6px;font-size:0.82rem;color:#888;">
+        <strong>Tendances politiques non représentées :</strong>
+        l'<strong>extrême gauche</strong> (LO, NPA-Révolutionnaires, Parti des travailleurs — programmes nationaux sans déclinaison municipale précise) et
+        l'<strong>ultra-centre citoyen</strong> (Utiles 67 / Mohamed Sylla — programme trop général pour être comparé thèse par thèse).
+        En revanche, <strong>aucune liste de droite ou de centre-droit n'est absente</strong> : LR (Vetter), RN (Joron) et Horizons (Jakubowicz) figurent tous dans l'outil.
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

Adds a closing paragraph to the absent candidates section naming the political tendencies that are missing from the tool and explicitly noting that the right wing is fully represented.

## Details

The existing section explains each absent candidate individually. The new paragraph provides a synthesis:

- **Extrême gauche absent**: LO, NPA-Révolutionnaires, Parti des travailleurs (national programmes without precise municipal positions)
- **Ultra-centre absent**: Utiles 67 / Mohamed Sylla (LIOT affiliation — programme aspirational, no thematic comparisons possible)
- **Droite/centre-droit: fully present** — LR (Vetter), RN (Joron), Horizons (Jakubowicz) all in the tool

This corrects the potential misreading that the tool under-represents the right. It also correctly characterises Utiles 67 as ultra-centrist (not "gauche radicale" as sometimes described).

No JavaScript logic was changed. No new tests needed.

## Test plan

- [x] 96/96 tests pass (`npm test`)
- [ ] Manual check: new paragraph appears at the bottom of the "Pourquoi ces 6 candidat·es ?" card

Closes #30