### PR TITLE
feat: show documented positions count per candidate in results

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,6 +448,7 @@
     font-weight: 700;
   }
   .cand-score-label { font-size: 11px; color: var(--gray); }
+  .cand-doc-count { font-size: 10px; color: var(--gray); margin-top: 2px; }
 
   .score-bar-wrap {
     padding: 0 24px 20px;
@@ -1548,6 +1549,16 @@ function calcScore(candidateId) {
   return maxScore > 0 ? Math.round((score / maxScore) * 100) : 0;
 }
 
+function calcDocumentedCount(candidateId) {
+  let count = 0;
+  THESES.forEach(t => {
+    const cp = POSITIONS[candidateId]?.[t.id];
+    if (!cp?.stance) return;
+    if (cp.stance !== 'neutral' || !isUndocumented(cp.excerpt)) count++;
+  });
+  return count;
+}
+
 // =============================================
 // RESULTS
 // =============================================
@@ -1557,7 +1568,8 @@ function showResults() {
 
   const scores = CANDIDATES.map(c => ({
     ...c,
-    score: calcScore(c.id)
+    score: calcScore(c.id),
+    documentedCount: calcDocumentedCount(c.id)
   })).sort((a, b) => b.score - a.score);
 
   const list = document.getElementById('results-list');
@@ -1576,6 +1588,7 @@ function showResults() {
         <div class="cand-score-wrap">
           <div class="cand-score-pct" style="color:${c.color}">${c.score}%</div>
           <div class="cand-score-label">de concordance</div>
+          <div class="cand-doc-count">${c.documentedCount}/33 documentées</div>
         </div>
         <button class="toggle-detail" id="toggle-${c.id}">Positions</button>
       </div>

--- a/tests/detail.test.js
+++ b/tests/detail.test.js
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, beforeEach } from 'vitest';
 import { loadApp, resetState } from './helpers/load-app.js';
 
+
 describe('buildDetailHTML', () => {
   let app;
 
@@ -180,6 +181,47 @@ describe('buildDetailHTML', () => {
     test('returns valid HTML container even with no answers', () => {
       const html = app.buildDetailHTML(getBarseghian());
       expect(html).toContain('candidate-positions');
+    });
+  });
+});
+
+describe('calcDocumentedCount', () => {
+  let app;
+
+  beforeAll(() => {
+    app = loadApp();
+  });
+
+  test('returns a number between 0 and 33 for each candidate', () => {
+    app.CANDIDATES.forEach(c => {
+      const count = app.calcDocumentedCount(c.id);
+      expect(count).toBeGreaterThanOrEqual(0);
+      expect(count).toBeLessThanOrEqual(33);
+    });
+  });
+
+  test('returns 33 for candidates with all positions documented', () => {
+    // Barseghian has well-documented positions; verify count is high
+    const count = app.calcDocumentedCount('barseghian');
+    expect(count).toBeGreaterThanOrEqual(25);
+  });
+
+  test('counts undocumented neutrals as 0', () => {
+    // Jakubowicz has many neutral positions; count should reflect undocumented ones
+    const count = app.calcDocumentedCount('jakubowicz');
+    // He has 21 neutrals, some of which are undocumented, so count < 33
+    expect(count).toBeLessThan(33);
+  });
+
+  test('agree and disagree positions always count as documented', () => {
+    // All agree/disagree positions should be counted regardless of excerpt
+    app.CANDIDATES.forEach(c => {
+      const agreeDisagreeCount = app.THESES.filter(t => {
+        const pos = app.POSITIONS[c.id]?.[t.id];
+        return pos?.stance === 'agree' || pos?.stance === 'disagree';
+      }).length;
+      const docCount = app.calcDocumentedCount(c.id);
+      expect(docCount).toBeGreaterThanOrEqual(agreeDisagreeCount);
     });
   });
 });

--- a/tests/helpers/load-app.js
+++ b/tests/helpers/load-app.js
@@ -34,7 +34,7 @@ export function loadApp() {
     return {
       CANDIDATES, THESES, POSITIONS,
       userAnswers, selectedCandidates,
-      calcScore, buildDetailHTML, buildComparisonTable,
+      calcScore, calcDocumentedCount, isUndocumented, buildDetailHTML, buildComparisonTable,
       buildCompCheckboxes, buildReviewList, renderQuestion,
       castVote, startQuiz, nextQuestion, prevQuestion,
       toggleDoubleWeight, editQuestion, updateNextLabel,


### PR DESCRIPTION
## Summary

- Adds `calcDocumentedCount(candidateId)` to count positions that are sourced from press (not undocumented neutrals)
- Displays "X/33 documentées" under each candidate's concordance score in the results view
- Adds CSS class `.cand-doc-count` for the count display

## Motivation

Candidates less covered by the retained media sources accumulate more undocumented positions (scoring 0), creating a structural disadvantage invisible to users. This indicator makes documentation completeness transparent.

## Test plan

- [ ] `npm test` passes (103 tests)
- [ ] In browser: open the quiz, answer some questions, verify each candidate card shows "X/33 documentées" below the score percentage
- [ ] Verify Jakubowicz shows a lower count than Barseghian (expected given data)

Closes #33