### PR TITLE
feat: flag advocacy media sources in position detail

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,6 +534,18 @@
     text-decoration: none;
   }
   .pos-source a:hover { text-decoration: underline; }
+  .source-badge {
+    display: inline-block;
+    font-size: 9px;
+    font-weight: 700;
+    padding: 1px 5px;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    vertical-align: middle;
+    margin-left: 4px;
+  }
+  .source-advocacy { background: #FFF3E0; color: #E65100; border: 1px solid #FFCC80; }
 
   .toggle-detail {
     font-size: 12px;
@@ -1523,6 +1535,9 @@ function prevQuestion() {
   }
 }
 
+// Domains of media with explicit editorial advocacy (not neutral press)
+const ADVOCACY_DOMAINS = ['vert.eco'];
+
 // =============================================
 // SCORE CALCULATION
 // =============================================
@@ -1647,7 +1662,7 @@ function buildDetailHTML(candidate) {
           </div>
         </div>
         <div class="pos-source">
-          ${cp.excerpt} — <a href="${cp.url}" target="_blank" rel="noopener">Source ↗</a>
+          ${cp.excerpt} — <a href="${cp.url}" target="_blank" rel="noopener">Source ↗</a>${ADVOCACY_DOMAINS.some(d => cp.url.includes(d)) ? ' <span class="source-badge source-advocacy">média militant</span>' : ''}
         </div>
       </div>
     `;

--- a/tests/detail.test.js
+++ b/tests/detail.test.js
@@ -182,4 +182,24 @@ describe('buildDetailHTML', () => {
       expect(html).toContain('candidate-positions');
     });
   });
+
+  // -----------------------------------------------------------
+  // Source badges: advocacy media
+  // -----------------------------------------------------------
+  describe('advocacy source badge', () => {
+    test('shows advocacy badge for vert.eco source', () => {
+      // barseghian T16 is sourced from vert.eco
+      app.userAnswers.T16 = { vote: 'agree', double: false };
+      const html = app.buildDetailHTML(getBarseghian());
+      expect(html).toContain('source-advocacy');
+      expect(html).toContain('média militant');
+    });
+
+    test('does not show advocacy badge for non-advocacy sources', () => {
+      // barseghian T1 is from strasinfo.fr, not an advocacy domain
+      app.userAnswers.T1 = { vote: 'agree', double: false };
+      const html = app.buildDetailHTML(getBarseghian());
+      expect(html).not.toContain('source-advocacy');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `ADVOCACY_DOMAINS` constant listing media with explicit editorial advocacy (currently: `vert.eco`)
- Adds CSS classes `.source-badge` and `.source-advocacy` for visual badging
- Displays a "média militant" badge after source links in `buildDetailHTML` when the URL belongs to an advocacy domain

## Motivation

`vert.eco` is an ecology-advocacy outlet providing 8% of position references. Using advocacy media to categorize candidates on ecology theses is a methodological conflict of interest. This badge lets users know when to apply extra scrutiny.

## Test plan

- [ ] `npm test` passes (101 tests)
- [ ] In browser: answer a question related to T16 (Barseghian's position on finances, sourced from vert.eco) → badge "média militant" appears next to the source link
- [ ] Non-vert.eco sources show no badge

Closes #35