### PR TITLE
feat: add editorial AI agents for objectivity and source verification

### DIFF
--- a/.claude/commands/check-objectivity.md
+++ b/.claude/commands/check-objectivity.md
@@ -1,0 +1,54 @@
+# Audit d'objectivité des thèses
+
+Analyse toutes les thèses du Wahl-O-Mat pour détecter les biais de formulation.
+
+## Instructions
+
+1. Utilise le **Read tool** pour lire `index.html` et extraire le tableau `THESES`.
+2. Pour chaque thèse, applique les 5 critères ci-dessous.
+3. Produis le rapport complet en français.
+
+## Critères d'analyse
+
+Pour chaque thèse, évalue :
+
+### 1. Charge lexicale
+Présence de mots chargés émotionnellement ou politiquement : « enfin », « vraiment », « grave », « nécessaire », « indispensable », adverbes d'intensité (« absolument », « clairement »), superlatifs injustifiés.
+
+### 2. Présupposé implicite
+La thèse tient-elle pour acquis un fait contestable avant même que l'utilisateur réponde ?
+Exemple problématique : *« La ville doit accélérer la transition écologique »* (présuppose que la vitesse actuelle est insuffisante).
+Formulation neutre préférable : *« La ville doit adopter un rythme plus rapide de transition écologique »*.
+
+### 3. Falsifiabilité
+Un citoyen raisonnable peut-il légitimement répondre AUSSI BIEN « d'accord » que « pas d'accord » sans être perçu comme extrémiste ou irrationnel ? Si seule une réponse semble défendable, la thèse est biaisée.
+
+### 4. Asymétrie de charge argumentative
+L'une des réponses nécessite-t-elle beaucoup plus d'explication ou de justification que l'autre pour paraître crédible ?
+
+### 5. Clarté du périmètre
+La thèse est-elle suffisamment précise pour permettre une comparaison significative entre candidats ? Éviter les thèses trop vagues (« La ville doit améliorer les services publics ») qui recueilleraient l'accord de tous.
+
+## Format de sortie
+
+### Tableau d'analyse
+
+| ID | Thèse (extrait) | Critère | Sévérité | Problème constaté | Reformulation suggérée |
+|----|-----------------|---------|----------|-------------------|------------------------|
+| T1 | … | Présupposé | 🟡 Mineur | … | … |
+| T5 | … | Falsifiabilité | 🔴 Majeur | … | … |
+
+Sévérités :
+- ✅ Aucun problème
+- 🟡 Mineur — formulation perfectible mais acceptable
+- 🔴 Majeur — reformulation nécessaire avant publication
+
+### Résumé
+
+```
+Thèses sans problème :  XX / 33
+Problèmes mineurs (🟡) : XX
+Problèmes majeurs (🔴) : XX
+```
+
+Si des problèmes majeurs sont trouvés, suggère de créer un GitHub issue avec le label `chore` pour chaque thèse concernée.

--- a/.claude/commands/check-sources.md
+++ b/.claude/commands/check-sources.md
@@ -1,0 +1,60 @@
+# Vérification des sources
+
+Vérifie que les positions candidates dans le Wahl-O-Mat sont fidèles à leurs sources.
+
+## Arguments acceptés : $ARGUMENTS
+
+- Aucun argument → vérifie toutes les positions (peut être long : ~100+ URLs)
+- Un identifiant de candidat (`barseghian`, `trautmann`, `vetter`, `joron`, `kobryn`, `jakubowicz`) → limite à ce candidat
+- Un identifiant de thèse (`T1`…`T33`) → limite à cette thèse pour tous les candidats
+
+## Instructions
+
+1. Utilise le **Read tool** pour lire `index.html` et extraire `POSITIONS` et `CANDIDATES`.
+2. Si `$ARGUMENTS` est un identifiant de candidat connu, filtre les positions à ce candidat.
+3. Si `$ARGUMENTS` correspond au format `T\d+`, filtre à cette thèse pour tous les candidats.
+4. Pour chaque position dans le périmètre, utilise **WebFetch** avec le prompt suivant :
+   > « Cet extrait est-il présent ou fidèlement résumé dans cet article ? L'article permet-il de conclure que le candidat est d'accord / neutre / pas d'accord avec cette idée ? Extrait : "[excerpt]" | Position déclarée : [stance] »
+5. Produis le rapport complet en français.
+
+## Ce que tu vérifies pour chaque position
+
+### 1. Accessibilité de l'URL
+L'article est-il accessible ? (pas de 404, pas de paywall bloquant intégralement le contenu)
+
+### 2. Fidélité de l'extrait
+L'`excerpt` est-il présent textuellement dans l'article, ou en est-il un résumé fidèle sans déformation ?
+Signale toute paraphrase qui change le sens ou amplifie une position.
+
+### 3. Exactitude de la stance
+La valeur `stance` (`agree` / `neutral` / `disagree`) correspond-elle à ce que l'article dit réellement ?
+Attention aux :
+- Citations sorties de contexte
+- Positions conditionnelles présentées comme fermes
+- Prises de position passées présentées comme actuelles
+
+## Format de sortie
+
+### Tableau de vérification
+
+| Candidat | Thèse | URL | Extrait fidèle | Stance exacte | Sévérité | Notes |
+|----------|-------|-----|----------------|---------------|----------|-------|
+| Barseghian | T1 | ✅ Accessible | ✅ Fidèle | ✅ Correcte | ✅ OK | — |
+| Trautmann | T3 | ⚠️ Paywall | ❓ Non vérifiable | ❓ Non vérifiable | 🟡 Mineur | Contenu inaccessible |
+| Vetter | T7 | ✅ Accessible | ❌ Déformé | ✅ Correcte | 🔴 Majeur | L'extrait omet une condition importante |
+
+Sévérités :
+- ✅ OK — position vérifiée, aucun problème
+- 🟡 Mineur — URL injoignable ou paywall (non falsifiable, mais structurellement valide)
+- 🔴 Majeur — extrait inexact ou stance incorrecte → correction nécessaire
+
+### Résumé
+
+```
+Positions vérifiées :      XX
+  dont ✅ OK :             XX
+  dont 🟡 Mineures :       XX (URL inaccessible)
+  dont 🔴 Majeures :       XX (contenu incorrect)
+```
+
+Si des problèmes majeurs sont trouvés, suggère de créer un GitHub issue avec le label `chore` pour chaque position concernée, en indiquant le candidat, la thèse, et la correction à apporter.

--- a/.claude/hooks/remind-editorial-checks.sh
+++ b/.claude/hooks/remind-editorial-checks.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse hook: remind to run editorial AI agents when index.html is modified.
+# Fires after Edit, Write, NotebookEdit.
+
+set -euo pipefail
+
+INPUT="$(cat)"
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tool_input', {}).get('file_path', ''))
+except:
+    print('')
+" 2>/dev/null || true)
+
+if [[ "$FILE_PATH" == *"/index.html" ]]; then
+  cat <<'REMINDER'
+---------------------------------------------------
+EDITORIAL CHECKS REMINDER (automated hook)
+---------------------------------------------------
+index.html was modified. Run the relevant check:
+
+  THESES changed?    /check-objectivity
+  POSITIONS changed? /check-sources <candidate-id>
+                     /check-sources <T1..T33>
+
+These agents verify neutrality, source accuracy,
+and excerpt faithfulness before opening a PR.
+---------------------------------------------------
+REMINDER
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,6 +62,15 @@
             "command": "bash .claude/hooks/remind-git-workflow.sh"
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/remind-editorial-checks.sh"
+          }
+        ]
       }
     ]
   }

--- a/tests/data-integrity.test.js
+++ b/tests/data-integrity.test.js
@@ -157,5 +157,19 @@ describe('data integrity', () => {
           .toBeGreaterThanOrEqual(15);
       });
     });
+
+    test('no position url points to a listing or tag page', () => {
+      const listingPatterns = [/\/tag\//, /\/tags\//, /\/category\//, /\/categorie\//, /\/author\//, /\/auteur\//, /\/page\/\d+/];
+      Object.entries(POSITIONS).forEach(([candidateId, positions]) => {
+        Object.entries(positions).forEach(([thesisId, pos]) => {
+          listingPatterns.forEach(pattern => {
+            expect(
+              pattern.test(pos.url),
+              `${candidateId}.${thesisId} url looks like a listing page: ${pos.url}`
+            ).toBe(false);
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Add `/check-objectivity` slash command: analyses all 33 theses for linguistic bias (lexical charge, presupposition, falsifiability, asymmetry, scope clarity) and outputs a severity-coded French markdown table
- Add `/check-sources` slash command: fetches source URLs via WebFetch and verifies excerpt faithfulness and stance accuracy per candidate/thesis, with optional filtering by candidate ID or thesis ID (T1–T33)
- Add `remind-editorial-checks.sh` PostToolUse hook: fires automatically after any edit to `index.html` and reminds to run the relevant editorial command before opening a PR
- Add `data-integrity.test.js` test: blocks listing/tag/category/author page URLs in POSITIONS at the CI level

## Motivation

`data-integrity.test.js` validates structure (URL format, required fields) but not content quality. These additions create an automated editorial review layer:
- The slash commands let Claude analyse neutrality and source faithfulness on demand
- The hook ensures the commands are not forgotten when `index.html` changes
- The new test prevents listing pages from being used as sources (structural guard)

## Test plan

- [x] 114 tests pass (`npm test`)
- [x] `/check-objectivity` produces a French markdown audit table for all 33 theses
- [x] `/check-sources barseghian` limits scope to one candidate
- [x] `/check-sources T1` limits scope to one thesis across all candidates
- [x] Hook fires after Edit/Write to index.html and shows the editorial reminder
- [x] Hook is silent for edits to other files
- [x] New data-integrity test catches listing-page URLs and would have blocked the tag-page regression

Closes #44